### PR TITLE
Move plugin guidelines from repository

### DIFF
--- a/en/Plugins/Releasing/Submission requirements for plugins.md
+++ b/en/Plugins/Releasing/Submission requirements for plugins.md
@@ -1,0 +1,23 @@
+This page lists extends the [[Developer policies]] with plugin-specific requirements that all plugins must follow to be published.
+
+## Only use `fundingUrl` to link to services for financial support
+
+Use [[Manifest#fundingUrl|fundingUrl]] if you accept financial support for your plugin, using services like Buy Me A Coffee or GitHub Sponsors.
+
+If you don't accept donations, remove `fundingUrl` from your manifest.
+
+## Node.js and Electron APIs are only allowed on desktop
+
+The Node.js and Electron APIs are only available in the desktop version of Obsidian. For example, Node.js packages like `fs`, `crypto`, and `os`, are only available on desktop.
+
+If your plugin uses any of these APIs, you **must** set `isDesktopOnly` to `true` in the `manifest.json`.
+
+> [!tip]
+> Many Node.js features have Web API alternatives:
+>
+> - [`SubtleCrypto`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) instead of [`crypto`](https://nodejs.org/api/crypto.html).
+> - `navigator.clipboard.readText()` and `navigator.clipboard.writeText()` to access clipboard contents.
+
+## Don't include the plugin ID in the command ID
+
+Obsidian automatically prefixes command IDs with your plugin ID. You don't need to include the plugin ID yourself.


### PR DESCRIPTION
Moving guidelines from https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md.