### PR TITLE
✨ Art: Corrects --page-title-font

### DIFF
--- a/en/Reference/CSS variables/Publish/Site fonts.md
+++ b/en/Reference/CSS variables/Publish/Site fonts.md
@@ -15,5 +15,6 @@ Publish-specific variables should be defined on the `.published-container`.
 | `--font-monospace-theme` | Font family for code                                  |
 | `--font-interface-theme` | Font family for interface elements such as navigation |
 | `--font-mermaid`         | Font family for Mermaid diagrams                      |
+| `--page-title-font`      | Font family for [[Site pages]]                                                       |
 
 

--- a/en/Reference/CSS variables/Publish/Site pages.md
+++ b/en/Reference/CSS variables/Publish/Site pages.md
@@ -22,7 +22,7 @@ The note title displayed at the top of the page. This title can be hidden in the
 | Variable                   | Description                       |
 | -------------------------- | --------------------------------- |
 | `--page-title-color`       | Font color                        |
-| `--page-title-font`        | Font family                       |
+| `--page-title-font`        | Font family, see also [[Site fonts]]                       |
 | `--page-title-line-height` | Line height                       |
 | `--page-title-size`        | Font size                         |
 | `--page-title-style`       | Font style, e.g. normal or italic |

--- a/en/Reference/CSS variables/Publish/Site pages.md
+++ b/en/Reference/CSS variables/Publish/Site pages.md
@@ -22,7 +22,7 @@ The note title displayed at the top of the page. This title can be hidden in the
 | Variable                   | Description                       |
 | -------------------------- | --------------------------------- |
 | `--page-title-color`       | Font color                        |
-| `--page-title-font`        | Font family, see also [[Site fonts]]                       |
+| `--page-title-font`        | Font family, see [[Site fonts]]                       |
 | `--page-title-line-height` | Line height                       |
 | `--page-title-size`        | Font size                         |
 | `--page-title-style`       | Font style, e.g. normal or italic |


### PR DESCRIPTION
Please reassign this to the correct branch.. not sure which one yet. :)

**What this is**

- This is a simple change, which adds `--page-title-font` to the Site Fonts page as well. After thinking about it, I left the original one in, and included a link to Site fonts. Similarly, vice versa. Similarly, vice versa.

**Reasoning**

Technically, this variable would belong in both categories, but it's not feasible to create an "overlap" category, or similar. What made sense to me was to add it to both, and link to the opposing pages as well. 

I'll happily change it if there is some conformity clash. 