### PR TITLE
Fix: Capitalize "Sample Theme"

### DIFF
--- a/en/Themes/App themes/Build a theme.md
+++ b/en/Themes/App themes/Build a theme.md
@@ -30,7 +30,7 @@ The sample theme you'll use in this tutorial is available in a [GitHub repositor
 2. Clone the sample theme using Git.
 
    ```bash
-   git clone https://github.com/obsidianmd/obsidian-sample-theme.git "Sample theme"
+   git clone https://github.com/obsidianmd/obsidian-sample-theme.git "Sample Theme"
    ```
 
 > [!tip] GitHub template repository


### PR DESCRIPTION
Folder name and name in the manifest not having the same casing of "Sample Theme" leads to issues, see https://discord.com/channels/686053708261228577/931552763467411487/1120596210076631120

and another case:
https://discord.com/channels/686053708261228577/931552763467411487/1123799461827719189