### PR TITLE
Build a Plugin; Fix incorrect statement in step 5

### DIFF
--- a/en/Plugins/Getting started/Build a plugin.md
+++ b/en/Plugins/Getting started/Build a plugin.md
@@ -121,7 +121,7 @@ To let the user interact with your plugin, add a _ribbon icon_ that greets the u
 
 You can now see a dice icon in the ribbon on the left side of the Obsidian window. Select it to display a message in the upper-right corner.
 
-Notice how you didn't need to restart Obsidian after changing the source code, like when you updated the `manifest.json`.
+Remember, you need to **reload your plugin after changing the source code**, either by disabling it then enabling it again in the community plugins panel, or using the command palette as detailed in part 5 of this step.  
 
 > [!tip] Hot reloading
 > Install the [Hot-Reload](https://github.com/pjeby/hot-reload) plugin to automatically reload your plugin while developing.


### PR DESCRIPTION
Plugins do need a reload after changing the source in vanilla obsidian, unless hot reload is installed.