### PR TITLE
Update icon docs to specify max supported version

### DIFF
--- a/en/Plugins/User interface/Icons.md
+++ b/en/Plugins/User interface/Icons.md
@@ -4,6 +4,8 @@ Several of the UI components in the Obsidian API lets you configure an accompany
 
 Browse to [lucide.dev](https://lucide.dev/) to see all available icons and their corresponding names.
 
+**Please note:** Only icons up to v0.171.0 are supported at this time.
+
 ## Draw icons
 
 If you'd like to use icons in your custom interfaces, use the [[setIcon|setIcon()]] utility function to add an icon to an [[HTML elements|HTML element]]. The following example adds icon to the status bar:


### PR DESCRIPTION
# Overview

While going through the docs to learn how to develop a new plugin, I discovered that a particular icon would not work. The Obsidian Developer Tools gave no indication of an error occurring, leading to some confusion on my part. After some investigation, it appears that icons up to v0.171.0 are supported, but entering the name of an icon released in a later version (as well as arbitrary strings) results in a failure to display anything and no errors output.

## Problem:

The current documentation directs developers to browse icons at [lucide.dev](https://lucide.dev/) but does not specify the icon release version supported. Icons beyond v0.171.0 do not appear to be supported.

## Solution:

I've added a note to the `Icons.md` file to specify the maximum supported version, v0.171.0.