### PR TITLE
Remove superfluous step from the Build a plugin page

### DIFF
--- a/en/Plugins/Getting started/Build a plugin.md
+++ b/en/Plugins/Getting started/Build a plugin.md
@@ -99,23 +99,15 @@ Remember to restart Obsidian whenever you make changes to `manifest.json`.
 
 ## Step 5: Update the source code
 
-To let the user interact with your plugin, add a _ribbon icon_ that greets the user when they select it.
+To let the user interact with your plugin, a _ribbon icon_ is added that greets the user when they select it.
 
 1. Open `main.ts` in your code editor.
 2. Rename the plugin class from `MyPlugin` to `HelloWorldPlugin`.
-3. In the `onload()` method, add the following code:
-
-   ```ts
-   this.addRibbonIcon('dice', 'Greet', () => {
-     new Notice('Hello, world!');
-   });
-   ```
-
-4. In the **Command palette**, select **Reload app without saving** to reload the plugin.
+3. In the **Command palette**, select **Reload app without saving** to reload the plugin.
 
 You can now see a dice icon in the ribbon on the left side of the Obsidian window. Select it to display a message in the upper-right corner.
 
-Remember, you need to **reload your plugin after changing the source code**, either by disabling it then enabling it again in the community plugins panel, or using the command palette as detailed in part 4 of this step.  
+Remember, you need to **reload your plugin after changing the source code**, either by disabling it then enabling it again in the community plugins panel, or using the command palette as detailed in part 3 of this step.  
 
 > [!tip] Hot reloading
 > Install the [Hot-Reload](https://github.com/pjeby/hot-reload) plugin to automatically reload your plugin while developing.

--- a/en/Plugins/Getting started/Build a plugin.md
+++ b/en/Plugins/Getting started/Build a plugin.md
@@ -115,7 +115,7 @@ To let the user interact with your plugin, add a _ribbon icon_ that greets the u
 
 You can now see a dice icon in the ribbon on the left side of the Obsidian window. Select it to display a message in the upper-right corner.
 
-Remember, you need to **reload your plugin after changing the source code**, either by disabling it then enabling it again in the community plugins panel, or using the command palette as detailed in part 5 of this step.  
+Remember, you need to **reload your plugin after changing the source code**, either by disabling it then enabling it again in the community plugins panel, or using the command palette as detailed in part 4 of this step.  
 
 > [!tip] Hot reloading
 > Install the [Hot-Reload](https://github.com/pjeby/hot-reload) plugin to automatically reload your plugin while developing.

--- a/en/Plugins/Getting started/Build a plugin.md
+++ b/en/Plugins/Getting started/Build a plugin.md
@@ -103,13 +103,7 @@ To let the user interact with your plugin, add a _ribbon icon_ that greets the u
 
 1. Open `main.ts` in your code editor.
 2. Rename the plugin class from `MyPlugin` to `HelloWorldPlugin`.
-3. Import `Notice` from the `obsidian` package.
-
-   ```ts
-   import { Notice, Plugin } from "obsidian";
-   ```
-
-4. In the `onload()` method, add the following code:
+3. In the `onload()` method, add the following code:
 
    ```ts
    this.addRibbonIcon('dice', 'Greet', () => {
@@ -117,7 +111,7 @@ To let the user interact with your plugin, add a _ribbon icon_ that greets the u
    });
    ```
 
-5. In the **Command palette**, select **Reload app without saving** to reload the plugin.
+4. In the **Command palette**, select **Reload app without saving** to reload the plugin.
 
 You can now see a dice icon in the ribbon on the left side of the Obsidian window. Select it to display a message in the upper-right corner.
 


### PR DESCRIPTION
Those `import`s are already in the latest version of the template.