### PR TITLE
Fix WikiLinks from "Plugins" to "References/TypeScript API"

### DIFF
--- a/en/Plugins/Editor/Editor.md
+++ b/en/Plugins/Editor/Editor.md
@@ -1,4 +1,4 @@
-The [[Reference/TypeScript API/Editor/Editor|Editor]] class exposes operations for reading and manipulating an active Markdown document in edit mode.
+The [[Reference/TypeScript API/Editor|Editor]] class exposes operations for reading and manipulating an active Markdown document in edit mode.
 
 If you want to access the editor in a command, use the [[Commands#Editor commands|editorCallback]].
 

--- a/en/Plugins/Getting started/Use React in your plugin.md
+++ b/en/Plugins/Getting started/Use React in your plugin.md
@@ -88,7 +88,7 @@ You can mount your React component on any `HTMLElement`, for example [[Plugins/U
 
 ## Create an App context
 
-If you want to access the [[Reference/TypeScript API/App/App|App]] object from one of your React components, you need to pass it as a dependency. As your plugin grows, even though you're only using the `App` object in a few places, you start passing it through the whole component tree.
+If you want to access the [[Reference/TypeScript API/App|App]] object from one of your React components, you need to pass it as a dependency. As your plugin grows, even though you're only using the `App` object in a few places, you start passing it through the whole component tree.
 
 Another alternative is to create a React context for the app to make it globally available to all components inside your React view.
 

--- a/en/Plugins/User interface/Modals.md
+++ b/en/Plugins/User interface/Modals.md
@@ -1,4 +1,4 @@
-Modals display information and accept input from the user. To create a modal, create a class that extends [[Reference/TypeScript API/Modal/Modal|Modal]]:
+Modals display information and accept input from the user. To create a modal, create a class that extends [[Reference/TypeScript API/Modal|Modal]]:
 
 ```ts
 import { App, Modal } from "obsidian";

--- a/en/Plugins/User interface/Workspace.md
+++ b/en/Plugins/User interface/Workspace.md
@@ -114,7 +114,7 @@ export default class ExamplePlugin extends Plugin {
 
 ## Leaf lifecycle
 
-Plugins can add leaves of any type to the workspace, as well as define new leaf types through [[Views|custom views]]. Here are a few ways to add a leaf to the workspace. For more ways, refer to [[Reference/TypeScript API/Workspace/Workspace|Workspace]].
+Plugins can add leaves of any type to the workspace, as well as define new leaf types through [[Views|custom views]]. Here are a few ways to add a leaf to the workspace. For more ways, refer to [[Reference/TypeScript API/Workspace|Workspace]].
 
 - If you want to add a new leaf in the root split, use [[getLeaf|getLeaf(true)]].
 - If you want to add a new leaf in any of the side bars, use [[getLeftLeaf|getLeftLeaf()]] and [[getRightLeaf|getRightLeaf()]]. Both let you decide whether to add the leaf to a new split.

--- a/en/Plugins/Vault.md
+++ b/en/Plugins/Vault.md
@@ -1,6 +1,6 @@
 Each collection of notes in Obsidian is known as a Vault. A Vault consists of a folder, and any sub-folders within it.
 
-While your plugin can access the file system like any other Node.js application, the [[Reference/TypeScript API/Vault/Vault|Vault]] module aims to make it easier to work with files and folders within a Vault.
+While your plugin can access the file system like any other Node.js application, the [[en/Reference/TypeScript API/Vault|Vault]] module aims to make it easier to work with files and folders within a Vault.
 
 The following example recursively prints the paths of all Markdown files in a Vault:
 

--- a/en/Plugins/Vault.md
+++ b/en/Plugins/Vault.md
@@ -1,6 +1,6 @@
 Each collection of notes in Obsidian is known as a Vault. A Vault consists of a folder, and any sub-folders within it.
 
-While your plugin can access the file system like any other Node.js application, the [[en/Reference/TypeScript API/Vault|Vault]] module aims to make it easier to work with files and folders within a Vault.
+While your plugin can access the file system like any other Node.js application, the [[Reference/TypeScript API/Vault|Vault]] module aims to make it easier to work with files and folders within a Vault.
 
 The following example recursively prints the paths of all Markdown files in a Vault:
 


### PR DESCRIPTION
Fix not-working WikiLinks in docs from "Plugins" directory pointing to "References/TypeScript API" as they didn't work neither on the website nor locally.