### PR TITLE
Fix inaccurate explanation for `activeEditor`

### DIFF
--- a/en/Plugins/Releasing/Plugin guidelines.md
+++ b/en/Plugins/Releasing/Plugin guidelines.md
@@ -155,7 +155,11 @@ if (view) {
 If you want to access the editor in the active note, use `activeEditor` instead:
 
 ```ts
-const editor = this.app.workspace.activeEditor;
+const editor = this.app.workspace.activeEditor?.editor;
+
+if (editor) {
+    // ...
+}
 ```
 
 ### Avoid managing references to custom views


### PR DESCRIPTION
### What I did

- Adjusted an inaccurate code sample present in `Plugin guidelines.md`.

Closes: https://github.com/obsidianmd/obsidian-developer-docs/issues/91