### PR TITLE
Update ribbon actions, and add note about alternate methods

### DIFF
--- a/en/Plugins/User interface/Ribbon actions.md
+++ b/en/Plugins/User interface/Ribbon actions.md
@@ -1,4 +1,4 @@
-The sidebar on the left side of the Obsidian interface is mainly known as the _ribbon_. In addition to system operations, such as opening the preferences or another vault, the ribbon can also host actions defined by plugins.
+The sidebar on the left side of the Obsidian interface is mainly known as the _ribbon_. The purpose of the ribbon is to host actions defined by plugins.
 
 To add a action to the ribbon, use the [[addRibbonIcon|addRibbonIcon()]] method:
 
@@ -15,3 +15,6 @@ export default class ExamplePlugin extends Plugin {
 ```
 
 The first argument specifies which icon to use. For more information on the available icons, and how to add your own, refer to [[Plugins/User interface/Icons|Icons]].
+
+> [!note]
+> Users can remove your plugin's icon from the ribbon, or even opt to hide the ribbon entirely. Therefore it's advisable to include alternate ways of accessing functionality that's in the ribbon, such as creating a [[Plugins/User interface/Commands|command]].


### PR DESCRIPTION
The description of `Ribbon actions.md` is outdated as of version 1.6, so updated it. 

I also took the opportunity to add a note about providing alternate methods to access the functions in the ribbon.