### PR TITLE
Switch to single quotes

### DIFF
--- a/config/post-process.js
+++ b/config/post-process.js
@@ -46,16 +46,16 @@ cssclasses: hide-title
 				newFileContent = newFileContent.replaceAll('$docssite$', 'https://docs.obsidian.md');
 				newFileContent = newFileContent.replace(/\[([^\[]+)\](\((.*?)\))/g, function(_, x, y) {
 					if(y.includes('constructor')) {
-						return `[${x}]${y.replaceAll(".", "/")}`;
+						return `[${x}]${y.replaceAll('.', '/')}`;
 					}
-					if(y.includes("'")) {
-						return `[${x}]${y.replaceAll(".", "/")}`;
+					if(y.includes('\'')) {
+						return `[${x}]${y.replaceAll('.', '/')}`;
 					}
-					if(y.includes("https://")) {
+					if(y.includes('https://')) {
 						return `[${x}]${y}`;
 					}
 
-					return `[${x}]${y.slice(0, -4).replaceAll(".", "/")})`;
+					return `[${x}]${y.slice(0, -4).replaceAll('.', '/')})`;
 				});
 
 				await fs.writeFile(filePath, newFileContent, {encoding: 'utf-8'});

--- a/config/pre-process.js
+++ b/config/pre-process.js
@@ -13,7 +13,7 @@ async function each(members) {
 		if(member.docComment) {
 			if(member.docComment.includes('getLeaf')) {
 				const regex = /{@link Workspace.getLeaf(.*)}/g;
-				member.docComment = member.docComment.replace(regex, "::Workspace.getLeaf::$1::")
+				member.docComment = member.docComment.replace(regex, '::Workspace.getLeaf::$1::')
 			}
 		}
 

--- a/en/Plugins/Editor/Communicating with editor extensions.md
+++ b/en/Plugins/Editor/Communicating with editor extensions.md
@@ -3,7 +3,7 @@ Once you've built your editor extension, you might want to communicate with it f
 You can access the CodeMirror 6 editor from a [[MarkdownView|MarkdownView]]. However, since the Obsidian API doesn't actually expose the editor, you need to tell TypeScript to trust that it's there, using `@ts-expect-error`.
 
 ```ts
-import { EditorView } from "@codemirror/view";
+import { EditorView } from '@codemirror/view';
 
 // @ts-expect-error, not typed
 const editorView = view.editor.cm as EditorView;
@@ -15,8 +15,8 @@ You can access the [[View plugins|view plugin]] instance from the `EditorView.pl
 
 ```ts
 this.addCommand({
-	id: "example-editor-command",
-	name: "Example editor command",
+	id: 'example-editor-command',
+	name: 'Example editor command',
 	editorCallback: (editor, view) => {
 		// @ts-expect-error, not typed
 		const editorView = view.editor.cm as EditorView;
@@ -36,8 +36,8 @@ You can dispatch changes and [[State fields#Dispatching state effects|dispatch s
 
 ```ts
 this.addCommand({
-	id: "example-editor-command",
-	name: "Example editor command",
+	id: 'example-editor-command',
+	name: 'Example editor command',
 	editorCallback: (editor, view) => {
 		// @ts-expect-error, not typed
 		const editorView = view.editor.cm as EditorView;

--- a/en/Plugins/Editor/Decorations.md
+++ b/en/Plugins/Editor/Decorations.md
@@ -58,13 +58,13 @@ Widgets are custom HTML elements that you can add to the editor. You can either 
 The following example defines a widget that returns an HTML element, `<span>👉</span>`. You'll use this widget later on.
 
 ```ts
-import { EditorView, WidgetType } from "@codemirror/view";
+import { EditorView, WidgetType } from '@codemirror/view';
 
 export class EmojiWidget extends WidgetType {
   toDOM(view: EditorView): HTMLElement {
-    const div = document.createElement("span");
+    const div = document.createElement('span');
 
-    div.innerText = "👉";
+    div.innerText = '👉';
 
     return div;
   }
@@ -93,20 +93,20 @@ To provide decorations from a state field:
    ```
 
 ```ts
-import { syntaxTree } from "@codemirror/language";
+import { syntaxTree } from '@codemirror/language';
 import {
   Extension,
   RangeSetBuilder,
   StateField,
   Transaction,
-} from "@codemirror/state";
+} from '@codemirror/state';
 import {
   Decoration,
   DecorationSet,
   EditorView,
   WidgetType,
-} from "@codemirror/view";
-import { EmojiWidget } from "emoji";
+} from '@codemirror/view';
+import { EmojiWidget } from 'emoji';
 
 export const emojiListField = StateField.define<DecorationSet>({
   create(state): DecorationSet {
@@ -117,7 +117,7 @@ export const emojiListField = StateField.define<DecorationSet>({
 
     syntaxTree(transaction.state).iterate({
       enter(node) {
-        if (node.type.name.startsWith("list")) {
+        if (node.type.name.startsWith('list')) {
           // Position of the '-' or the '*'.
           const listCharFrom = node.from - 2;
 
@@ -152,8 +152,8 @@ To manage your decorations using a view plugin:
 Not all updates are reasons to rebuild your decorations. The following example only rebuilds decorations whenever the underlying document or the viewport changes.
 
 ```ts
-import { syntaxTree } from "@codemirror/language";
-import { RangeSetBuilder } from "@codemirror/state";
+import { syntaxTree } from '@codemirror/language';
+import { RangeSetBuilder } from '@codemirror/state';
 import {
   Decoration,
   DecorationSet,
@@ -163,8 +163,8 @@ import {
   ViewPlugin,
   ViewUpdate,
   WidgetType,
-} from "@codemirror/view";
-import { EmojiWidget } from "emoji";
+} from '@codemirror/view';
+import { EmojiWidget } from 'emoji';
 
 class EmojiListPlugin implements PluginValue {
   decorations: DecorationSet;
@@ -189,7 +189,7 @@ class EmojiListPlugin implements PluginValue {
         from,
         to,
         enter(node) {
-          if (node.type.name.startsWith("list")) {
+          if (node.type.name.startsWith('list')) {
             // Position of the '-' or the '*'.
             const listCharFrom = node.from - 2;
 

--- a/en/Plugins/Editor/Editor.md
+++ b/en/Plugins/Editor/Editor.md
@@ -25,16 +25,16 @@ The [[replaceRange|replaceRange()]] method replaces the text between two cursor 
 The following command inserts today's date at the cursor position:
 
 ```ts
-import { Editor, moment, Plugin } from "obsidian";
+import { Editor, moment, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     this.addCommand({
-      id: "insert-todays-date",
-      name: "Insert today's date",
+      id: 'insert-todays-date',
+      name: 'Insert today\'s date',
       editorCallback: (editor: Editor) => {
         editor.replaceRange(
-          moment().format("YYYY-MM-DD"),
+          moment().format('YYYY-MM-DD'),
           editor.getCursor()
         );
       },
@@ -52,13 +52,13 @@ If you want to modify the selected text, use [[replaceSelection|replaceSelection
 The following command reads the current selection and converts it to uppercase:
 
 ```ts
-import { Editor, Plugin } from "obsidian";
+import { Editor, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     this.addCommand({
-      id: "convert-to-uppercase",
-      name: "Convert to uppercase",
+      id: 'convert-to-uppercase',
+      name: 'Convert to uppercase',
       editorCallback: (editor: Editor) => {
         const selection = editor.getSelection();
         editor.replaceSelection(selection.toUpperCase());

--- a/en/Plugins/Editor/Markdown post processing.md
+++ b/en/Plugins/Editor/Markdown post processing.md
@@ -3,22 +3,22 @@ If you want to change how a Markdown document is rendered in Reading view, you c
 The following example looks for any code block that contains a text between two colons, `:`, and replaces it with an appropriate emoji:
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 const ALL_EMOJIS: Record<string, string> = {
-  ":+1:": "👍",
-  ":sunglasses:": "😎",
-  ":smile:": "😄",
+  ':+1:': '👍',
+  ':sunglasses:': '😎',
+  ':smile:': '😄',
 };
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     this.registerMarkdownPostProcessor((element, context) => {
-      const codeblocks = element.findAll("code");
+      const codeblocks = element.findAll('code');
 
       for (let codeblock of codeblocks) {
         const text = codeblock.innerText.trim();
-        if (text[0] === ":" && text[text.length - 1] === ":") {
+        if (text[0] === ':' && text[text.length - 1] === ':') {
           const emojiEl = codeblock.createSpan({
             text: ALL_EMOJIS[text] ?? text,
           });
@@ -51,23 +51,23 @@ flowchart LR
 If you want to add your own custom code blocks like the Mermaid one, you can use [[registerMarkdownCodeBlockProcessor|registerMarkdownCodeBlockProcessor()]]. The following example renders a code block with CSV data, as a table:
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
-    this.registerMarkdownCodeBlockProcessor("csv", (source, el, ctx) => {
-      const rows = source.split("\n").filter((row) => row.length > 0);
+    this.registerMarkdownCodeBlockProcessor('csv', (source, el, ctx) => {
+      const rows = source.split('\n').filter((row) => row.length > 0);
 
-      const table = el.createEl("table");
-      const body = table.createEl("tbody");
+      const table = el.createEl('table');
+      const body = table.createEl('tbody');
 
       for (let i = 0; i < rows.length; i++) {
-        const cols = rows[i].split(",");
+        const cols = rows[i].split(',');
 
-        const row = body.createEl("tr");
+        const row = body.createEl('tr');
 
         for (let j = 0; j < cols.length; j++) {
-          row.createEl("td", { text: cols[j] });
+          row.createEl('td', { text: cols[j] });
         }
       }
     });

--- a/en/Plugins/Editor/State management.md
+++ b/en/Plugins/Editor/State management.md
@@ -8,10 +8,10 @@ This page aims to give an introduction to state management for [[Editor extensio
 In most applications, you would update state by assigning a new value to a property or variable. As a consequence, the old value is lost forever.
 
 ```ts
-let note = "";
-note = "Heading"
-note = "# Heading"
-note = "## Heading" // How to undo this?
+let note = '';
+note = 'Heading'
+note = '# Heading'
+note = '## Heading' // How to undo this?
 ```
 
 To support features like undoing and redoing changes to a user's workspace, applications like Obsidian instead keep a history of all changes that have been made. To undo a change, you can then go back to a point in time before the change was made.
@@ -28,9 +28,9 @@ In TypeScript, you'd then end up with something like this:
 ```ts
 const changes: ChangeSpec[] = [];
 
-changes.push({ from: 0, insert: "Heading" });
-changes.push({ from: 0, insert: "# " });
-changes.push({ from: 0, insert: "#" });
+changes.push({ from: 0, insert: 'Heading' });
+changes.push({ from: 0, insert: '# ' });
+changes.push({ from: 0, insert: '#' });
 ```
 
 ## Transactions

--- a/en/Plugins/Editor/View plugins.md
+++ b/en/Plugins/Editor/View plugins.md
@@ -22,7 +22,7 @@ import {
   PluginValue,
   EditorView,
   ViewPlugin,
-} from "@codemirror/view";
+} from '@codemirror/view';
 
 class ExamplePlugin implements PluginValue {
   constructor(view: EditorView) {

--- a/en/Plugins/Events.md
+++ b/en/Plugins/Events.md
@@ -3,7 +3,7 @@ Many of the interfaces in the Obsidian lets you subscribe to events throughout t
 Any registered event handlers need to be detached whenever the plugin unloads. The safest way to make sure this happens is to use the [[registerEvent|registerEvent()]] method.
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
@@ -21,7 +21,7 @@ If you want to repeatedly call a function with a fixed delay, use the [`window.s
 The following example displays the current time in the status bar, updated every second:
 
 ```ts
-import { moment, Plugin } from "obsidian";
+import { moment, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   statusBar: HTMLElement;
@@ -37,7 +37,7 @@ export default class ExamplePlugin extends Plugin {
   }
 
   updateStatusBar() {
-    this.statusBar.setText(moment().format("H:mm:ss"));
+    this.statusBar.setText(moment().format('H:mm:ss'));
   }
 }
 ```
@@ -46,5 +46,5 @@ export default class ExamplePlugin extends Plugin {
 > [Moment](https://momentjs.com/) is a popular JavaScript library for working with dates and time. Obsidian uses Moment internally, so you don't need to install it yourself. You can import it from the Obsidian API instead:
 >
 > ```ts
-> import { moment } from "obsidian";
+> import { moment } from 'obsidian';
 > ```

--- a/en/Plugins/Getting started/Anatomy of a plugin.md
+++ b/en/Plugins/Getting started/Anatomy of a plugin.md
@@ -1,7 +1,7 @@
 The [[Plugin|Plugin]] class defines the lifecycle of a plugin and exposes the operations available to all plugins:
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
@@ -27,7 +27,7 @@ To view the console:
 2. Click on the Console tab in the Developer Tools window.
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {

--- a/en/Plugins/Getting started/Build a plugin.md
+++ b/en/Plugins/Getting started/Build a plugin.md
@@ -106,7 +106,7 @@ To let the user interact with your plugin, add a _ribbon icon_ that greets the u
 3. Import `Notice` from the `obsidian` package.
 
    ```ts
-   import { Notice, Plugin } from "obsidian";
+   import { Notice, Plugin } from 'obsidian';
    ```
 
 4. In the `onload()` method, add the following code:

--- a/en/Plugins/Getting started/Mobile development.md
+++ b/en/Plugins/Getting started/Mobile development.md
@@ -42,7 +42,7 @@ You can inspect Obsidian on an iOS device running 16.4 or later and a macOS base
 To detect the platform your plugin is running on, you can use [[Platform]]:
 
 ```ts
-import { Platform } from "obsidian";
+import { Platform } from 'obsidian';
 
 if (Platform.isIosApp) {
   // ...

--- a/en/Plugins/Getting started/Use React in your plugin.md
+++ b/en/Plugins/Getting started/Use React in your plugin.md
@@ -45,12 +45,12 @@ export const ReactView = () => {
 To use the React component, it needs to be mounted on a [[HTML elements]]. The following example mounts the `ReactView` component on the `this.containerEl.children[1]` element:
 
 ```tsx
-import { StrictMode } from "react";
-import { ItemView, WorkspaceLeaf } from "obsidian";
-import { Root, createRoot } from "react-dom/client";
-import { ReactView } from "./ReactView";
+import { StrictMode } from 'react';
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import { Root, createRoot } from 'react-dom/client';
+import { ReactView } from './ReactView';
 
-const VIEW_TYPE_EXAMPLE = "example-view";
+const VIEW_TYPE_EXAMPLE = 'example-view';
 
 class ExampleView extends ItemView {
 	root: Root | null = null;
@@ -64,7 +64,7 @@ class ExampleView extends ItemView {
 	}
 
 	getDisplayText() {
-		return "Example view";
+		return 'Example view';
 	}
 
 	async onOpen() {
@@ -95,8 +95,8 @@ Another alternative is to create a React context for the app to make it globally
 1. Use `createContext()` to create a new app context.
 
    ```tsx title="context.ts"
-   import { createContext } from "react";
-   import { App } from "obsidian";
+   import { createContext } from 'react';
+   import { App } from 'obsidian';
 
    export const AppContext = createContext<App | undefined>(undefined);
    ```
@@ -115,8 +115,8 @@ Another alternative is to create a React context for the app to make it globally
 3. Create a custom hook to make it easier to use the context in your components.
 
    ```tsx title="hooks.ts"
-   import { useContext } from "react";
-   import { AppContext } from "./context";
+   import { useContext } from 'react';
+   import { AppContext } from './context';
 
    export const useApp = (): App | undefined => {
      return useContext(AppContext);
@@ -126,7 +126,7 @@ Another alternative is to create a React context for the app to make it globally
 4. Use the hook in any React component within `ReactView` to access the app.
 
    ```tsx title="ReactView.tsx"
-   import { useApp } from "./hooks";
+   import { useApp } from './hooks';
 
    export const ReactView = () => {
      const { vault } = useApp();

--- a/en/Plugins/Getting started/Use Svelte in your plugin.md
+++ b/en/Plugins/Getting started/Use Svelte in your plugin.md
@@ -41,8 +41,8 @@ To build a Svelte application, you need to install the dependencies and configur
 4. In `esbuild.config.mjs`, add the following imports to the top of the file:
 
    ```js
-   import esbuildSvelte from "esbuild-svelte";
-   import sveltePreprocess from "svelte-preprocess";
+   import esbuildSvelte from 'esbuild-svelte';
+   import sveltePreprocess from 'svelte-preprocess';
    ```
 
 5. Add Svelte to the list of plugins.
@@ -84,11 +84,11 @@ In the root directory of the plugin, create a new file called `Component.svelte`
 To use the Svelte component, it needs to be mounted on an existing [[HTML elements|HTML element]]. For example, if you are mounting on a custom [[ItemView|ItemView]] in Obsidian:
 
 ```ts
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, WorkspaceLeaf } from 'obsidian';
 
-import Component from "./Component.svelte";
+import Component from './Component.svelte';
 
-export const VIEW_TYPE_EXAMPLE = "example-view";
+export const VIEW_TYPE_EXAMPLE = 'example-view';
 
 export class ExampleView extends ItemView {
   component: Component;
@@ -102,7 +102,7 @@ export class ExampleView extends ItemView {
   }
 
   getDisplayText() {
-    return "Example view";
+    return 'Example view';
   }
 
   async onOpen() {
@@ -140,8 +140,8 @@ To create a store for your plugin and access it from within a generic Svelte com
 1. Create a file called `store.ts`:
 
    ```jsx
-   import { writable } from "svelte/store";
-   import type ExamplePlugin from "./main";
+   import { writable } from 'svelte/store';
+   import type ExamplePlugin from './main';
 
    const plugin = writable<ExamplePlugin>();
    export default { plugin };
@@ -150,12 +150,12 @@ To create a store for your plugin and access it from within a generic Svelte com
 2. Configure the store:
 
    ```ts
-   import { ItemView, WorkspaceLeaf } from "obsidian";
-   import type ExamplePlugin from "./main";
-   import store from "./store";
-   import Component from "./Component.svelte";
+   import { ItemView, WorkspaceLeaf } from 'obsidian';
+   import type ExamplePlugin from './main';
+   import store from './store';
+   import Component from './Component.svelte';
 
-   const VIEW_TYPE_EXAMPLE = "example-view";
+   const VIEW_TYPE_EXAMPLE = 'example-view';
 
    class ExampleView extends ItemView {
      // ...
@@ -177,7 +177,7 @@ To create a store for your plugin and access it from within a generic Svelte com
 
    ```jsx
    <script lang="ts">
-     import type MyPlugin from "./main";
+     import type MyPlugin from './main';
 
      let plugin: MyPlugin;
      store.plugin.subscribe((p) => (plugin = p));

--- a/en/Plugins/Releasing/Plugin guidelines.md
+++ b/en/Plugins/Releasing/Plugin guidelines.md
@@ -104,7 +104,7 @@ When possible, use methods like [[registerEvent|registerEvent()]] or [[addComman
 ```ts
 export default class MyPlugin extends Plugin {
   onload() {
-    this.registerEvent(this.app.vault.on("create", this.onCreate));
+    this.registerEvent(this.app.vault.on('create', this.onCreate));
   }
 
   onCreate: (file: TAbstractFile) => {
@@ -269,8 +269,8 @@ Use [[normalizePath|normalizePath()]] whenever you accept user-defined paths to 
 - Runs the path through [String.prototype.normalize](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize).
 
 ```ts
-import { normalizePath } from "obsidian";
-const pathToPlugin = normalizePath("//my-folder\file");
+import { normalizePath } from 'obsidian';
+const pathToPlugin = normalizePath('//my-folder\file');
 // pathToPlugin contains "my-folder/file" not "//my-folder\"
 ```
 

--- a/en/Plugins/User interface/Commands.md
+++ b/en/Plugins/User interface/Commands.md
@@ -5,15 +5,15 @@ Commands are actions that the user can perform from the [Command Palette](https:
 To register a new command for your plugin, call the [[addCommand|addCommand()]] method inside the `onload()` method:
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     this.addCommand({
-      id: "print-greeting-to-console",
-      name: "Print greeting to console",
+      id: 'print-greeting-to-console',
+      name: 'Print greeting to console',
       callback: () => {
-        console.log("Hey, you!");
+        console.log('Hey, you!');
       },
     });
   }
@@ -110,7 +110,7 @@ In this example, the user can run the command by pressing and holding Ctrl (or C
 this.addCommand({
   id: 'example-command',
   name: 'Example command',
-  hotkeys: [{ modifiers: ["Mod", "Shift"], key: "a" }],
+  hotkeys: [{ modifiers: ['Mod', 'Shift'], key: 'a' }],
   callback: () => {
     console.log('Hey, you!');
   },

--- a/en/Plugins/User interface/Context menus.md
+++ b/en/Plugins/User interface/Context menus.md
@@ -1,28 +1,28 @@
 If you want to open up a context menu, use [[Menu|Menu]]:
 
 ```ts
-import { Menu, Notice, Plugin } from "obsidian";
+import { Menu, Notice, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
-    this.addRibbonIcon("dice", "Open menu", (event) => {
+    this.addRibbonIcon('dice', 'Open menu', (event) => {
       const menu = new Menu();
 
       menu.addItem((item) =>
         item
-          .setTitle("Copy")
-          .setIcon("documents")
+          .setTitle('Copy')
+          .setIcon('documents')
           .onClick(() => {
-            new Notice("Copied");
+            new Notice('Copied');
           })
       );
 
       menu.addItem((item) =>
         item
-          .setTitle("Paste")
-          .setIcon("paste")
+          .setTitle('Paste')
+          .setIcon('paste')
           .onClick(() => {
-            new Notice("Pasted");
+            new Notice('Pasted');
           })
       );
 
@@ -44,16 +44,16 @@ You can also add an item to the file menu, or the editor menu, by subscribing to
 ![[context-menu-positions.png]]
 
 ```ts
-import { Notice, Plugin } from "obsidian";
+import { Notice, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     this.registerEvent(
-      this.app.workspace.on("file-menu", (menu, file) => {
+      this.app.workspace.on('file-menu', (menu, file) => {
         menu.addItem((item) => {
           item
-            .setTitle("Print file path 👈")
-            .setIcon("document")
+            .setTitle('Print file path 👈')
+            .setIcon('document')
             .onClick(async () => {
               new Notice(file.path);
             });
@@ -62,11 +62,11 @@ export default class ExamplePlugin extends Plugin {
     );
 
   this.registerEvent(
-      this.app.workspace.on("editor-menu", (menu, editor, view) => {
+      this.app.workspace.on('editor-menu', (menu, editor, view) => {
         menu.addItem((item) => {
           item
-            .setTitle("Print file path 👈")
-            .setIcon("document")
+            .setTitle('Print file path 👈')
+            .setIcon('document')
             .onClick(async () => {
               new Notice(view.file.path);
             });

--- a/en/Plugins/User interface/HTML elements.md
+++ b/en/Plugins/User interface/HTML elements.md
@@ -1,7 +1,7 @@
 Several components in the Obsidian API, such as the [[Settings]], expose _container elements_:
 
 ```ts
-import { App, PluginSettingTab } from "obsidian";
+import { App, PluginSettingTab } from 'obsidian';
 
 class ExampleSettingTab extends PluginSettingTab {
   plugin: ExamplePlugin;
@@ -29,15 +29,15 @@ Every `HTMLElement`, including the container element, exposes a `createEl()` met
 For example, here's how you can add an `<h1>` heading element inside the container element:
 
 ```ts
-containerEl.createEl("h1", { text: "Heading 1" });
+containerEl.createEl('h1', { text: 'Heading 1' });
 ```
 
 `createEl()` returns a reference to the new element:
 
 ```ts
-const book = containerEl.createEl("div");
-book.createEl("div", { text: "How to Take Smart Notes" });
-book.createEl("small", { text: "Sönke Ahrens" });
+const book = containerEl.createEl('div');
+book.createEl('div', { text: 'How to Take Smart Notes' });
+book.createEl('small', { text: 'Sönke Ahrens' });
 ```
 
 ## Style your elements
@@ -65,9 +65,9 @@ You can add custom CSS styles to your plugin by adding a `styles.css` file in th
 To make the HTML elements use the styles, set the `cls` property for the HTML element:
 
 ```ts
-const book = containerEl.createEl("div", { cls: "book" });
-book.createEl("div", { text: "How to Take Smart Notes", cls: "book__title" });
-book.createEl("small", { text: "Sönke Ahrens", cls: "book__author" });
+const book = containerEl.createEl('div', { cls: 'book' });
+book.createEl('div', { text: 'How to Take Smart Notes', cls: 'book__title' });
+book.createEl('small', { text: 'Sönke Ahrens', cls: 'book__author' });
 ```
 
 Now it looks much better! 🎉
@@ -79,5 +79,5 @@ Now it looks much better! 🎉
 Use the `toggleClass` method if you want to change the style of an element based on the user's settings or other values:
 
 ```ts
-element.toggleClass("danger", status === "error");
+element.toggleClass('danger', status === 'error');
 ```

--- a/en/Plugins/User interface/Icons.md
+++ b/en/Plugins/User interface/Icons.md
@@ -11,12 +11,12 @@ Browse to [lucide.dev](https://lucide.dev/) to see all available icons and their
 If you'd like to use icons in your custom interfaces, use the [[setIcon|setIcon()]] utility function to add an icon to an [[HTML elements|HTML element]]. The following example adds icon to the status bar:
 
 ```ts
-import { Plugin, setIcon } from "obsidian";
+import { Plugin, setIcon } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     const item = this.addStatusBarItem();
-    setIcon(item, "info");
+    setIcon(item, 'info');
   }
 }
 ```
@@ -34,14 +34,14 @@ div {
 To add a custom icon for your plugin, use the [[addIcon|addIcon()]] utility:
 
 ```ts
-import { addIcon, Plugin } from "obsidian";
+import { addIcon, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
-    addIcon("circle", `<circle cx="50" cy="50" r="50" fill="currentColor" />`);
+    addIcon('circle', `<circle cx="50" cy="50" r="50" fill="currentColor" />`);
 
-    this.addRibbonIcon("circle", "Click me", () => {
-      console.log("Hello, you!");
+    this.addRibbonIcon('circle', 'Click me', () => {
+      console.log('Hello, you!');
     });
   }
 }

--- a/en/Plugins/User interface/Modals.md
+++ b/en/Plugins/User interface/Modals.md
@@ -1,12 +1,12 @@
 Modals display information and accept input from the user. To create a modal, create a class that extends [[Reference/TypeScript API/Modal|Modal]]:
 
 ```ts
-import { App, Modal } from "obsidian";
+import { App, Modal } from 'obsidian';
 
 export class ExampleModal extends Modal {
   constructor(app: App) {
     super(app);
-	this.setContent("Look at me, I'm a modal! 👀")
+	this.setContent('Look at me, I\'m a modal! 👀')
   }
 }
 ```
@@ -14,14 +14,14 @@ export class ExampleModal extends Modal {
 To open a modal, create a new instance of `ExampleModal` and call [[Reference/TypeScript API/Modal/open|open()]] on it:
 
 ```ts
-import { Plugin } from "obsidian";
-import { ExampleModal } from "./modal";
+import { Plugin } from 'obsidian';
+import { ExampleModal } from './modal';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     this.addCommand({
-      id: "display-modal",
-      name: "Display modal",
+      id: 'display-modal',
+      name: 'Display modal',
       callback: () => {
         new ExampleModal(this.app).open();
       },
@@ -37,16 +37,16 @@ The modal in the previous example only displayed some text. Let's look at a litt
 ![[modal-input.png]]
 
 ```ts
-import { App, Modal, Setting } from "obsidian";
+import { App, Modal, Setting } from 'obsidian';
 
 export class ExampleModal extends Modal {
   constructor(app: App, onSubmit: (result: string) => void) {
     super(app);
-	this.setTitle("What's your name?");
+	this.setTitle('What\'s your name?');
 
 	let name = '';
     new Setting(this.contentEl)
-      .setName("Name")
+      .setName('Name')
       .addText((text) =>
         text.onChange((value) => {
           name = value;
@@ -55,7 +55,7 @@ export class ExampleModal extends Modal {
     new Setting(this.contentEl)
       .addButton((btn) =>
         btn
-          .setButtonText("Submit")
+          .setButtonText('Submit')
           .setCta()
           .onClick(() => {
             this.close();
@@ -80,7 +80,7 @@ new ExampleModal(this.app, (result) => {
 ![[suggest-modal.gif]]
 
 ```ts
-import { App, Notice, SuggestModal } from "obsidian";
+import { App, Notice, SuggestModal } from 'obsidian';
 
 interface Book {
   title: string;
@@ -89,16 +89,16 @@ interface Book {
 
 const ALL_BOOKS = [
   {
-    title: "How to Take Smart Notes",
-    author: "Sönke Ahrens",
+    title: 'How to Take Smart Notes',
+    author: 'Sönke Ahrens',
   },
   {
-    title: "Thinking, Fast and Slow",
-    author: "Daniel Kahneman",
+    title: 'Thinking, Fast and Slow',
+    author: 'Daniel Kahneman',
   },
   {
-    title: "Deep Work",
-    author: "Cal Newport",
+    title: 'Deep Work',
+    author: 'Cal Newport',
   },
 ];
 
@@ -112,8 +112,8 @@ export class ExampleModal extends SuggestModal<Book> {
 
   // Renders each suggestion item.
   renderSuggestion(book: Book, el: HTMLElement) {
-    el.createEl("div", { text: book.title });
-    el.createEl("small", { text: book.author });
+    el.createEl('div', { text: book.title });
+    el.createEl('small', { text: book.author });
   }
 
   // Perform action on the selected suggestion.

--- a/en/Plugins/User interface/Ribbon actions.md
+++ b/en/Plugins/User interface/Ribbon actions.md
@@ -3,12 +3,12 @@ The sidebar on the left side of the Obsidian interface is mainly known as the _r
 To add a action to the ribbon, use the [[addRibbonIcon|addRibbonIcon()]] method:
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
-    this.addRibbonIcon("dice", "Print to console", () => {
-      console.log("Hello, you!");
+    this.addRibbonIcon('dice', 'Print to console', () => {
+      console.log('Hello, you!');
     });
   }
 }

--- a/en/Plugins/User interface/Settings.md
+++ b/en/Plugins/User interface/Settings.md
@@ -7,15 +7,15 @@ In this guide, you'll learn how to create a settings page like this 👇
 The main reason to add settings to a plugin is to store configuration that persists even after the user quits Obsidian. The following example demonstrates how to save and load settings from disk:
 
 ```ts
-import { Plugin } from "obsidian";
-import { ExampleSettingTab } from "./settings";
+import { Plugin } from 'obsidian';
+import { ExampleSettingTab } from './settings';
 
 interface ExamplePluginSettings {
   dateFormat: string;
 }
 
 const DEFAULT_SETTINGS: Partial<ExamplePluginSettings> = {
-  dateFormat: "YYYY-MM-DD",
+  dateFormat: 'YYYY-MM-DD',
 };
 
 export default class ExamplePlugin extends Plugin {
@@ -101,7 +101,7 @@ Object.assign({}, DEFAULT_SETTINGS, await this.loadData())
 
 ```ts
 const DEFAULT_SETTINGS: Partial<ExamplePluginSettings> = {
-  dateFormat: "YYYY-MM-DD",
+  dateFormat: 'YYYY-MM-DD',
 };
 ```
 
@@ -119,8 +119,8 @@ this.addSettingTab(new ExampleSettingTab(this.app, this));
 Here, the `ExampleSettingTab` is a class that extends [[PluginSettingTab|PluginSettingTab]]:
 
 ```ts
-import ExamplePlugin from "./main";
-import { App, PluginSettingTab, Setting } from "obsidian";
+import ExamplePlugin from './main';
+import { App, PluginSettingTab, Setting } from 'obsidian';
 
 export class ExampleSettingTab extends PluginSettingTab {
   plugin: ExamplePlugin;
@@ -136,11 +136,11 @@ export class ExampleSettingTab extends PluginSettingTab {
     containerEl.empty();
 
     new Setting(containerEl)
-      .setName("Date format")
-      .setDesc("Default date format")
+      .setName('Date format')
+      .setDesc('Default date format')
       .addText((text) =>
         text
-          .setPlaceholder("MMMM dd, yyyy")
+          .setPlaceholder('MMMM dd, yyyy')
           .setValue(this.plugin.settings.dateFormat)
           .onChange(async (value) => {
             this.plugin.settings.dateFormat = value;

--- a/en/Plugins/User interface/Status bar.md
+++ b/en/Plugins/User interface/Status bar.md
@@ -4,12 +4,12 @@ To create a new block in the status bar, call the [[addStatusBarItem|addStatusBa
 > Custom status bar items [are **not** supported](https://discord.com/channels/686053708261228577/707816848615407697/832321402106544179) on Obsidian mobile apps.
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     const item = this.addStatusBarItem();
-    item.createEl("span", { text: "Hello from the status bar 👋" });
+    item.createEl('span', { text: 'Hello from the status bar 👋' });
   }
 }
 ```
@@ -20,17 +20,17 @@ export default class ExamplePlugin extends Plugin {
 You can add multiple status bar items by calling `addStatusBarItem()` multiple times. Since Obsidian adds a gap between them, you need to create multiple HTML element on the same status bar item if you need more control of spacing.
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
     const fruits = this.addStatusBarItem();
-    fruits.createEl("span", { text: "🍎" });
-    fruits.createEl("span", { text: "🍌" });
+    fruits.createEl('span', { text: '🍎' });
+    fruits.createEl('span', { text: '🍌' });
 
     const veggies = this.addStatusBarItem();
-    veggies.createEl("span", { text: "🥦" });
-    veggies.createEl("span", { text: "🥬" });
+    veggies.createEl('span', { text: '🥦' });
+    veggies.createEl('span', { text: '🥬' });
   }
 }
 ```

--- a/en/Plugins/User interface/Views.md
+++ b/en/Plugins/User interface/Views.md
@@ -3,9 +3,9 @@ Views determine how Obsidian displays content. The file explorer, graph view, an
 To create a custom view, create a class that extends the [[ItemView|ItemView]] interface:
 
 ```ts
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, WorkspaceLeaf } from 'obsidian';
 
-export const VIEW_TYPE_EXAMPLE = "example-view";
+export const VIEW_TYPE_EXAMPLE = 'example-view';
 
 export class ExampleView extends ItemView {
   constructor(leaf: WorkspaceLeaf) {
@@ -17,13 +17,13 @@ export class ExampleView extends ItemView {
   }
 
   getDisplayText() {
-    return "Example view";
+    return 'Example view';
   }
 
   async onOpen() {
     const container = this.containerEl.children[1];
     container.empty();
-    container.createEl("h4", { text: "Example view" });
+    container.createEl('h4', { text: 'Example view' });
   }
 
   async onClose() {
@@ -45,8 +45,8 @@ Each view is uniquely identified by a text string and several operations require
 Custom views need to be registered when the plugin is enabled, and cleaned up when the plugin is disabled:
 
 ```ts
-import { Plugin, WorkspaceLeaf } from "obsidian";
-import { ExampleView, VIEW_TYPE_EXAMPLE } from "./view";
+import { Plugin, WorkspaceLeaf } from 'obsidian';
+import { ExampleView, VIEW_TYPE_EXAMPLE } from './view';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
@@ -55,7 +55,7 @@ export default class ExamplePlugin extends Plugin {
       (leaf) => new ExampleView(leaf)
     );
 
-    this.addRibbonIcon("dice", "Activate view", () => {
+    this.addRibbonIcon('dice', 'Activate view', () => {
       this.activateView();
     });
   }

--- a/en/Plugins/User interface/Workspace.md
+++ b/en/Plugins/User interface/Workspace.md
@@ -99,11 +99,11 @@ flowchart TD
 You can access the workspace through the [[App|App]] object. The following example prints the type of every leaf in the workspace:
 
 ```ts
-import { Plugin } from "obsidian";
+import { Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
-    this.addRibbonIcon("dice", "Print leaf types", () => {
+    this.addRibbonIcon('dice', 'Print leaf types', () => {
       this.app.workspace.iterateAllLeaves((leaf) => {
         console.log(leaf.getViewState().type);
       });
@@ -130,5 +130,5 @@ To remove a leaf from the workspace, call [[detach|detach()]] on the leaf you wa
 You can create [linked panes](https://help.obsidian.md/User+interface/Workspace/Panes/Linked+pane) by assigning multiple leaves to the same group, using [[setGroup|setGroup()]].
 
 ```ts
-leaves.forEach((leaf) => leaf.setGroup("group1");
+leaves.forEach((leaf) => leaf.setGroup('group1');
 ```

--- a/en/Plugins/Vault.md
+++ b/en/Plugins/Vault.md
@@ -28,11 +28,11 @@ There are two methods for reading the content of a file: [[Reference/TypeScript 
 The following example reads the content of all Markdown files in the Vault and returns the average document size:
 
 ```ts
-import { Notice, Plugin } from "obsidian";
+import { Notice, Plugin } from 'obsidian';
 
 export default class ExamplePlugin extends Plugin {
   async onload() {
-    this.addRibbonIcon("info", "Calculate average file length", async () => {
+    this.addRibbonIcon('info', 'Calculate average file length', async () => {
       const fileLength = await this.averageFileLength();
       new Notice(`The average file length is ${fileLength} characters.`);
     });
@@ -71,7 +71,7 @@ If you want to modify a file based on its current content, use [[process|Vault.p
 // emojify replaces all occurrences of :) with 🙂.
 function emojify(vault: Vault, file: TFile): Promise<string> {
   return vault.process(file, (data) => {
-    return data.replace(":)", "🙂");
+    return data.replace(':)', '🙂');
   })
 }
 ```
@@ -102,11 +102,11 @@ When you use `trash()`, you have the option to move the file to the system's tra
 Some operations return or accept a [[TAbstractFile|TAbstractFile]] object, which can be either a file or a folder. Always check the concrete type of a `TAbstractFile` before you use it.
 
 ```ts
-const folderOrFile = this.app.vault.getAbstractFileByPath("folderOrFile");
+const folderOrFile = this.app.vault.getAbstractFileByPath('folderOrFile');
 
 if (folderOrFile instanceof TFile) {
-  console.log("It's a file!");
+  console.log('It\'s a file!');
 } else if (folderOrFile instanceof TFolder) {
-  console.log("It's a folder!");
+  console.log('It\'s a folder!');
 }
 ```


### PR DESCRIPTION
The most popular `js`/`ts` code style is to use single quotes.

[Obsidian API](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts) also uses single quotes

This PR changes all double quotes from code examples to single quotes.
