### PR TITLE
Fix broken link in Workspace.md

### DIFF
--- a/en/Plugins/User interface/Workspace.md
+++ b/en/Plugins/User interface/Workspace.md
@@ -127,7 +127,7 @@ To remove a leaf from the workspace, call [[detach|detach()]] on the leaf you wa
 
 ## Leaf groups
 
-You can create [linked panes](https://help.obsidian.md/User+interface/Workspace/Panes/Linked+pane) by assigning multiple leaves to the same group, using [[setGroup|setGroup()]].
+You can create [linked panes](https://help.obsidian.md/User+interface/Tabs#Linked+views) by assigning multiple leaves to the same group, using [[setGroup|setGroup()]].
 
 ```ts
 leaves.forEach((leaf) => leaf.setGroup('group1');

--- a/en/Plugins/User interface/Workspace.md
+++ b/en/Plugins/User interface/Workspace.md
@@ -127,7 +127,7 @@ To remove a leaf from the workspace, call [[detach|detach()]] on the leaf you wa
 
 ## Leaf groups
 
-You can create [linked panes](https://help.obsidian.md/User+interface/Tabs#Linked+views) by assigning multiple leaves to the same group, using [[setGroup|setGroup()]].
+You can create [linked views](https://help.obsidian.md/User+interface/Tabs#Linked+views) by assigning multiple leaves to the same group, using [[setGroup|setGroup()]].
 
 ```ts
 leaves.forEach((leaf) => leaf.setGroup('group1');


### PR DESCRIPTION
- Fixes 404 link to "linked panes"
- Updates link text from "linked panes" to "linked views", to align with wording in help docs 

_Assuming **linked views** are the same as **linked panes** - please reject if not_

Old (broken)
https://help.obsidian.md/User+interface/Workspace/Panes/Linked+pane

Corrected
https://help.obsidian.md/User+interface/Tabs#Linked+views