### PR TITLE
Update svelte guide to svelte 5

### DIFF
--- a/en/Plugins/Getting started/Use Svelte in your plugin.md
+++ b/en/Plugins/Getting started/Use Svelte in your plugin.md
@@ -1,8 +1,8 @@
 This guide explains how to configure your plugin to use [Svelte](https://svelte.dev/), a light-weight alternative to traditional frameworks like React and Vue.
 
-Svelte is built around a compiler that preprocesses your code and outputs vanilla JavaScript, which means it doesn't need to load any libraries at run time. This also means that it doesn't need a virtual DOM to track state changes, which allows your plugin to run with minimal additional overhead.
+Svelte is built around a compiler that preprocesses your code and outputs optimized vanilla JavaScript. This means that it doesn't need a virtual DOM to track state changes, which allows your plugin to run with minimal additional overhead.
 
-If you want to learn more about Svelte, and how to use it, refer to the [tutorial](https://svelte.dev/tutorial/basics) and the [documentation](https://svelte.dev/docs).
+If you want to learn more about Svelte, and how to use it, refer to the [tutorial](https://svelte.dev/tutorial/svelte/welcome-to-svelte) and the [documentation](https://svelte.dev/docs/svelte/overview).
 
 This guide assumes that you've finished [[Build a plugin]].
 
@@ -11,65 +11,94 @@ This guide assumes that you've finished [[Build a plugin]].
 
 ## Configure your plugin
 
-To build a Svelte application, you need to install the dependencies and configure your plugin to compile code written using Svelte.
+To build a plugin with Svelte, you need to install the dependencies and configure your plugin to compile code written using Svelte. 
+If you only want to use TypeScript's *type-only* features, you don't need `svelte-preprocess`.
 
 1. Add Svelte to your plugin dependencies:
 
    ```bash
-   npm install --save-dev svelte svelte-preprocess @tsconfig/svelte esbuild-svelte
+   npm install --save-dev svelte svelte-preprocess esbuild-svelte svelte-check
    ```
 
-2. Extend the `tsconfig.json` to enable additional type checking for common Svelte issues. The `types` property is important for TypeScript to recognize `.svelte` files.
+   > [!info]
+   > Svelte requires at least TypeScript 5.0. To update to Typescript 5.0 run the following in your terminal.
+   >
+   > ```bash
+   > npm update typescript@~5.0.0
+   > ```
+
+2. Extend the `tsconfig.json` to enable additional type checking for common Svelte issues. `verbatimModuleSyntax` is needed for `svelte-preprocess` and `skipLibCheck` is needed for `svelte-check` to work correctly.
 
    ```json
    {
-     "extends": "@tsconfig/svelte/tsconfig.json",
      "compilerOptions": {
-       "types": ["svelte", "node"],
-
+       "verbatimModuleSyntax": true,
+       "skipLibCheck": true,
        // ...
-     }
+     },
+     "include": [
+       "**/*.ts",
+       "**/*.svelte"
+     ]
    }
    ```
 
-3. Remove the following line from your `tsconfig.json` as it conflicts with the Svelte configuration.
-
-   ```json
-   "inlineSourceMap": true,
-   ```
-
-4. In `esbuild.config.mjs`, add the following imports to the top of the file:
+3. In `esbuild.config.mjs`, add the following imports to the top of the file:
 
    ```js
    import esbuildSvelte from 'esbuild-svelte';
    import sveltePreprocess from 'svelte-preprocess';
    ```
 
-5. Add Svelte to the list of plugins.
+4. Add Svelte to the list of plugins.
 
    ```js
-	const context = await esbuild.context({
-		plugins: [
-		  esbuildSvelte({
-			compilerOptions: { css: true },
-			preprocess: sveltePreprocess(),
-		  }),
-		],
-		// ...
-	});
+   const context = await esbuild.context({
+     plugins: [
+       esbuildSvelte({
+         compilerOptions: { css: 'injected' },
+         preprocess: sveltePreprocess(),
+       }),
+     ],
+     // ...
+   });
+   ```
+  
+5. Add a script to run `svelte-check` to your `package.json`.
+   
+   ```json
+   {
+     // ...
+     "scripts": {
+       // ...
+       "svelte-check": "svelte-check --tsconfig tsconfig.json"
+     }
+   }
    ```
 
 ## Create a Svelte component
 
-In the root directory of the plugin, create a new file called `Component.svelte`:
+In the root directory of the plugin, create a new file called `Counter.svelte`:
 
 ```tsx
 <script lang="ts">
-  export let variable: number;
+  interface Props {
+    startCount: number;
+  }
+
+  let {
+    startCount
+  }: Props = $props();
+
+  let count = $state(startCount);
+
+  export function increment() {
+    count += 1;
+  }
 </script>
 
 <div class="number">
-  <span>My number is {variable}!</span>
+  <span>My number is {count}!</span>
 </div>
 
 <style>
@@ -86,12 +115,15 @@ To use the Svelte component, it needs to be mounted on an existing [[HTML elemen
 ```ts
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 
-import Component from './Component.svelte';
+// Import the Counter Svelte component and the `mount` and `unmount` methods.
+import Counter from './Counter.svelte';
+import { mount, unmount } from 'svelte';
 
 export const VIEW_TYPE_EXAMPLE = 'example-view';
 
 export class ExampleView extends ItemView {
-  component: Component;
+  // A variable to hold on to the Counter instance mounted in this ItemView.
+  counter: ReturnType<typeof Counter> | undefined;
 
   constructor(leaf: WorkspaceLeaf) {
     super(leaf);
@@ -106,80 +138,23 @@ export class ExampleView extends ItemView {
   }
 
   async onOpen() {
-    this.component = new Component({
+    // Attach the Svelte component to the ItemViews content element and provide the needed props.
+    this.counter = mount({
       target: this.contentEl,
       props: {
-        variable: 1
+        startCount: 5,
       }
     });
+
+    // Since the component instance is typed, the exported `increment` method is known to TypeScript.
+    this.counter.increment();
   }
 
   async onClose() {
-    this.component.$destroy();
+    if (this.counter) {
+      // Remove the Counter from the ItemView.
+      unmount(this.counter);
+    }
   }
 }
 ```
-
-> [!info]
-> Svelte requires at least TypeScript 4.5. If you see the following error when you build the plugin, you need to upgrade TypeScript to a more recent version.
->
-> ```plain
-> error TS5023: Unknown compiler option 'preserveValueImports'.
-> ```
->
-> To fix the error, run the following in your terminal:
->
-> ```bash
-> npm update typescript@~4.5.0
-> ```
-
-## Create a Svelte store
-
-To create a store for your plugin and access it from within a generic Svelte component instead of passing the plugin as a prop, follow these steps:
-
-1. Create a file called `store.ts`:
-
-   ```jsx
-   import { writable } from 'svelte/store';
-   import type ExamplePlugin from './main';
-
-   const plugin = writable<ExamplePlugin>();
-   export default { plugin };
-   ```
-
-2. Configure the store:
-
-   ```ts
-   import { ItemView, WorkspaceLeaf } from 'obsidian';
-   import type ExamplePlugin from './main';
-   import store from './store';
-   import Component from './Component.svelte';
-
-   const VIEW_TYPE_EXAMPLE = 'example-view';
-
-   class ExampleView extends ItemView {
-     // ...
-
-     async onOpen() {
-       store.plugin.set(this.plugin);
-
-       this.component = new Component({
-         target: this.contentEl,
-         props: {
-           variable: 1
-         }
-       });
-     }
-   }
-   ```
-
-3. To use the store in your component:
-
-   ```jsx
-   <script lang="ts">
-     import type MyPlugin from './main';
-
-     let plugin: MyPlugin;
-     store.plugin.subscribe((p) => (plugin = p));
-   </script>
-   ```


### PR DESCRIPTION
I updated the svelte guide to svelte 5.

- Svelte now ships a minimal library at run time
- Updated links to the svelte docs
- `@tsconfig/svelte` is no longer required
- Added svelte check for command line type checking for svelte files (tsc does not cover this)
- Updated the example to svelte 5 and made it a bit more complex to showcase more features/interactions with normal TS
- Added comments to the TS part of the example
- Removed the store example. It is discouraged to use stores in svelte 5.