### PR TITLE
Add sufficient permissions

### DIFF
--- a/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
+++ b/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
@@ -13,7 +13,8 @@ Manually releasing your plugin can be time-consuming and error-prone. In this gu
    jobs:
      build:
        runs-on: ubuntu-latest
-
+       permissions:
+         contents: write
        steps:
          - uses: actions/checkout@v3
 


### PR DESCRIPTION
# What
- Extend sufficient permissions to allow access to the required resource for release

## Why
- Users should be able to run the template out of the box.

## Initial Issue
- Copied the template to https://github.com/eharris128/obsidian-bluesky/actions/runs/11743921813/job/32717842581
- Initial run ran into: 
![image](https://github.com/user-attachments/assets/a98f1be6-51bd-4e81-b020-d7cc9ff579d8)

## Now
- GitHub Actions works perfectly with these two new lines: 
https://github.com/eharris128/obsidian-bluesky/actions/runs/11744208833/job/32718767357
- Code diff on my repo - https://github.com/eharris128/obsidian-bluesky/commit/081f216a13d326f8788058dd5f39bd38dc34b094