### PR TITLE
Fixed typo in Plugins/Getting started/Use React in your plugin.md

### DIFF
--- a/en/Plugins/Getting started/Use React in your plugin.md
+++ b/en/Plugins/Getting started/Use React in your plugin.md
@@ -42,7 +42,7 @@ export const ReactView = () => {
 
 ## Mount the React component
 
-To use the React component, it needs to be mounted on a [[HTML elements]]. The following example mounts the `ReactView` component on the `this.containerEl.children[1]` element:
+To use the React component, it needs to be mounted on a [[HTML element]]. The following example mounts the `ReactView` component on the `this.containerEl.children[1]` element:
 
 ```tsx
 import { StrictMode } from 'react';


### PR DESCRIPTION
Fixed a small typo in the "Use React in your plugin" guide.