### PR TITLE
docs: add guide for supporting pop-out windows

### DIFF
--- a/en/Plugins/Guides/Supporting Pop-Out Windows.md
+++ b/en/Plugins/Guides/Supporting Pop-Out Windows.md
@@ -1,0 +1,56 @@
+With the release of [Obsidian v0.15.0](https://obsidian.md/changelog/2022-06-14-desktop-v0.15.0/), the pop-out windows feature was added to the desktop version of Obsidian. 
+
+For most plugins, this feature should work out-of-the-box. However, some things work differently when your plugin renders things in pop-out windows.
+
+Most importantly, pop-out windows come with a complete different set of globals. Each pop-out window introduces its own `Window` object, `Document` object, and fresh copies of all global constructors (like `HTMLElement` and `MouseEvent`).
+
+This means that some of the things you previously had assumed to be global and use only _a single_ definition, will now only work in the main window. Here are some examples:
+
+```ts
+let myElement: HTMLElement = ...;
+
+// This will always append to the main window
+document.body.appendChild(myElement);
+
+// This will actually be false if element is in a pop-out window
+if (myElement instanceof HTMLElement) {
+
+}
+
+element.on('click', '.my-css-class', (event) => {
+    // This will be false if the event is triggered in a pop-out window
+    if (event instanceof MouseEvent) {
+
+    }
+}
+```
+
+The Obsidian API includes various helper function and accessors to better support pop-out windows:
+
+- A global `activeWindow` and `activeDocument` variable, which always points to the current focused window and its document. 
+- An `element.win` and `element.doc` getter, which respectively point to the `Window` and `Document` objects that the element belongs to.
+- A function for performing cross-window compatible `instanceof` checks. Use `element.instanceOf(HTMLElement)` and `event.instanceOf(MouseEvent)`, instead of `element instanceof HTMLElement` and `event instanceof MouseEvent`.
+- `HTMLElement.onWindowMigrated(callback)` which hooks a callback on the element for when it is inserted into a different window than it originally was in. This can be used for complex renderers like canvases to re-initialize the rendering context.
+
+Using these APIs, the previous example would look like this:
+
+```ts
+let myElement: HTMLElement = ...;
+
+// Bad: myElement would be added to the currently focused document, which is not necessarily the one you want
+activeDocument.body.appendChild(myElement);
+// Good: This will append myElement to the same window as someElement
+someElement.doc.body.appendChild(myElement);
+
+// This will work correctly in pop-out windows
+if (myElement.instanceOf(HTMLElement)) {
+
+}
+
+element.on('click', '.my-css-class', (event) => {
+    // This will work correctly in pop-out windows
+    if (event.instanceOf(MouseEvent)) {
+
+    }
+}
+```


### PR DESCRIPTION
This is a preliminary PR for adding a brief guide on how to use proper APIs to support pop-out windows. The guide itself is mainly based on [the blog post](https://obsidian.md/blog/how-to-update-plugins-to-support-pop-out-windows/) written by Licat when the feature was first added.

Some of the notable changes include:
- Remove all 'we' references
- Reworded some sentences for clarity

---

This PR is ready to merge, but it might be useful to add some pointers for proper API usage. When searching around for existing plugins making use of these API's, I was wondering what the actual 'proper' usage is of them.

<details>
<summary>
<h3> Adding listeners on <code>window</code>/<code>document</code></h3>
</summary>

I found some plugins that makes use of the following construction (e.g. found in a View construction):
```ts
activeWindow.addEventListener('click', callback);
```

However, I feel like this isn't entirely correct. Aside from the fact that some of the plugin never even unregister the listener, there are also some other problems:
- If the vault is being initialised, and the view being exists in a pop-out window, then the listener would be added to the wrong window
- If the view gets dragged back into another window, the listener is never moved

```ts
// Bad: the event listener isn't necessarily added to the same window as the view
window.addEventListener('click', callback);

// Bad: the event listener isn't added to the same window as the view
activeWindow.addEventListener('click', callback);

// Bad: but if the view is moved back, the event listener is lost
this.containerEl.win.addEventListener('click', callback);

// Good: remove and re-add the event listener based on the window it is in
this.containerEl.win.addEventListener('click', callback);
this.containerEl.onWindowMigrate((win) => {
  win.addEventListener('click', callback);
});
```

<mark>Is it possible to get the previous window in `onWindowMigrate`? That way, the event listener can be correctly removed.</mark></details>


<details>
<summary>
<h3>Guideline for correct <code>window</code>/<code>document</code> access</h3>
</summary>

This question is more about devising a good guideline for when to use which `document`/`window` accessor API:
1. `document`/`window`: Never use this, `activeDocument`/`activeWindow` is _always_ better
2. `activeDocument`/`activeWindow`: Use this _only_ if you are sure that the window is in focus by the time your code is called
3. `element.doc`/`element.win` or `event.doc`/`event.win`: This always guarantees that the correct `document` or `window` is used

</details>




