### PR TITLE
Small typo fix

### DIFF
--- a/en/Reference/CSS variables/Plugins/File explorer.md
+++ b/en/Reference/CSS variables/Plugins/File explorer.md
@@ -9,7 +9,7 @@ This page lists CSS variables used by the [File explorer](https://help.obsidian.
 | Variable                          | Description                                                    |
 | --------------------------------- | -------------------------------------------------------------- |
 | `--vault-profile-display`         | `display` property for the vault profile                       |
-| `--vault-profile-actions-display` | `dsiplay` property for the action buttons in the vault profile |
+| `--vault-profile-actions-display` | `display` property for the action buttons in the vault profile |
 | `--vault-profile-font-size`       | Font size                                                      |
 | `--vault-profile-font-weight`     | Font weight                                                    |
 | `--vault-profile-color`           | Text color                                                     |

--- a/en/Reference/CSS variables/Window/Vault profile.md
+++ b/en/Reference/CSS variables/Window/Vault profile.md
@@ -9,7 +9,7 @@ This page lists CSS variables for the **Vault profile** component, in the bottom
 | Variable                          | Description                                                    |
 | --------------------------------- | -------------------------------------------------------------- |
 | `--vault-profile-display`         | `display` property for the vault profile                       |
-| `--vault-profile-actions-display` | `dsiplay` property for the action buttons in the vault profile |
+| `--vault-profile-actions-display` | `display` property for the action buttons in the vault profile |
 | `--vault-profile-font-size`       | Font size                                                      |
 | `--vault-profile-font-weight`     | Font weight                                                    |
 | `--vault-profile-color`           | Text color                                                     |


### PR DESCRIPTION
Stumbled upon a tiny typo in `Reference` > `CSS variables`:

- \> `Plugins` > `File explorer.md`
- \> `Window` > `Vault profile.md`

Which this PR should fix (if I didn't make any mistakes in the process 😇 )