### PR TITLE
Add guideline for plugins to not add their own toggles for ribbon items

### DIFF
--- a/en/Plugins/User interface/Ribbon actions.md
+++ b/en/Plugins/User interface/Ribbon actions.md
@@ -17,4 +17,4 @@ export default class ExamplePlugin extends Plugin {
 The first argument specifies which icon to use. For more information on the available icons, and how to add your own, refer to [[Plugins/User interface/Icons|Icons]].
 
 > [!note]
-> Users can remove your plugin's icon from the ribbon, or even opt to hide the ribbon entirely. Therefore it's advisable to include alternate ways of accessing functionality that's in the ribbon, such as creating a [[Plugins/User interface/Commands|command]].
+> Users can remove your plugin's icon from the ribbon, or even opt to hide the ribbon entirely. Therefore it's advisable to include alternate ways of accessing functionality that's in the ribbon, such as creating a [[Plugins/User interface/Commands|command]]. It is also recommended that plugins do not add their own toggles for ribbon items.


### PR DESCRIPTION
This guideline is enforced in plugin reviews but is not documented in the public facing documentation.