### PR TITLE
docs: clarify isDesktopOnly means only runs on desktop

### DIFF
--- a/en/Reference/Manifest.md
+++ b/en/Reference/Manifest.md
@@ -25,7 +25,7 @@ The following properties are only available to plugins.
 | --------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------|
 | `description`   | `string`  | **Yes**  | A description of your plugin.                                                                                                          |
 | `id`            | `string`  | **Yes**  | The ID of your plugin. The ID must contain only lowercase letters and hyphens, can't end with `plugin`, and can't contain `obsidian`.  |
-| `isDesktopOnly` | `boolean` | **Yes**  | Whether the plugin can be used only on desktop.                                                                                        |
+| `isDesktopOnly` | `boolean` | **Yes**  | Whether the plugin can only be used on the desktop app, for example because it uses NodeJS or Electron APIs.                          |
 
 > [!note]
 > For local development, the `id` should match the plugin's folder name; otherwise some methods, such as `onExternalSettingsChange`, won't be called.

--- a/en/Reference/Manifest.md
+++ b/en/Reference/Manifest.md
@@ -21,11 +21,11 @@ The following properties are available for both plugins and themes.
 
 The following properties are only available to plugins.
 
-| Property        | Type      | Required | Description                                                                                                                           |
-| --------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `description`   | `string`  | **Yes**  | A description of your plugin.                                                                                                         |
-| `id`            | `string`  | **Yes**  | The ID of your plugin. The ID must contain only lowercase letters and hyphens, can't end with `plugin`, and can't contain `obsidian`. |
-| `isDesktopOnly` | `boolean` | **Yes**  | Whether your plugin uses NodeJS or Electron APIs.                                                                                     |
+| Property        | Type      | Required | Description                                                                                                                            |
+| --------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------|
+| `description`   | `string`  | **Yes**  | A description of your plugin.                                                                                                          |
+| `id`            | `string`  | **Yes**  | The ID of your plugin. The ID must contain only lowercase letters and hyphens, can't end with `plugin`, and can't contain `obsidian`.  |
+| `isDesktopOnly` | `boolean` | **Yes**  | Whether the plugin can be used only on desktop.                                                                                        |
 
 > [!note]
 > For local development, the `id` should match the plugin's folder name; otherwise some methods, such as `onExternalSettingsChange`, won't be called.


### PR DESCRIPTION
This PR clarifies the description of the `isDesktopOnly` property in the plugin manifest documentation.

This update makes the intent clearer by explaining that the property indicates the plugin only works on the desktop version of Obsidian.

This matches other places in [Obsidian repos](https://github.com/search?q=repo%3Aobsidianmd%2Fobsidian-api%20isDesktopOnly&type=code) that mention this property.

I feel this is clearer from a plugin developer point of view, but happy to adjust the wording.