### PR TITLE
Fix empty check for value

### DIFF
--- a/en/Plugins/Guides/Build a Bases view.md
+++ b/en/Plugins/Guides/Build a Bases view.md
@@ -166,7 +166,7 @@ export class MyBasesView extends BasesView implements HoverParent {
   
             // Skip rendering properties which have an empty value.
             // The list items for each file may have differing length.
-            if (value.isEmpty()) continue;
+            if (!value || !value.isTruthy()) continue;
   
             if (!firstProp) {
               el.createSpan({


### PR DESCRIPTION
`entry.getValue` returns a [`Value | null`](https://github.com/obsidianmd/obsidian-api/blob/d5b94f56e3a909396ae05941e67ddb51a167180d/obsidian.d.ts#L699)

`isEmpty` doesn't exist on `Value` so use [`isTruthy`](https://github.com/obsidianmd/obsidian-api/blob/d5b94f56e3a909396ae05941e67ddb51a167180d/obsidian.d.ts#L6308) instead.