### PR TITLE
Fix typo in spacing CSS variables docs

### DIFF
--- a/en/Reference/CSS variables/Foundations/Spacing.md
+++ b/en/Reference/CSS variables/Foundations/Spacing.md
@@ -17,7 +17,7 @@ Each size variable contains two numbers which represent the base and the multipl
 - `--size-4-2` represents `8px` (4x2)
 - `--size-4-4` represents `16px` (4x4)
 
-In addition to the 4-pixel grid, Obsidan also provides a set of variables that uses a 2-pixel grid. Use these sparingly and only when you need more fine-grained spacing.
+In addition to the 4-pixel grid, Obsidian also provides a set of variables that uses a 2-pixel grid. Use these sparingly and only when you need more fine-grained spacing.
 
 | Variable      | Default value |
 | ------------- | ------------- |


### PR DESCRIPTION
## Summary

- Fixes a typo in the CSS variables spacing reference: `Obsidan` -> `Obsidian`.
- Touches only a non-generated docs page.

## Validation

- `git diff --check origin/main...HEAD`
- `rg -n "Obsidan" .` returned no matches

## Notes

No linked issue; the README says typo fixes can be submitted directly.
