### PR TITLE
Add artifact attestation step to example release workflow

### DIFF
--- a/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
+++ b/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
@@ -15,6 +15,8 @@ Manually releasing your plugin can be time-consuming and error-prone. In this gu
        runs-on: ubuntu-latest
        permissions:
          contents: write
+         id-token: write
+         attestations: write
        steps:
          - uses: actions/checkout@v3
 
@@ -28,6 +30,14 @@ Manually releasing your plugin can be time-consuming and error-prone. In this gu
              npm install
              npm run build
 
+         - name: Generate artifact attestation
+           uses: actions/attest-build-provenance@v3
+           with:
+             subject-path: |
+               main.js
+               manifest.json
+               styles.css
+
          - name: Create release
            env:
              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +49,8 @@ Manually releasing your plugin can be time-consuming and error-prone. In this gu
                --draft \
                main.js manifest.json styles.css
    ```
+
+   The **Generate artifact attestation** step creates a signed [build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) for your release assets, which is recommended when you submit a plugin to the community directory. If your plugin doesn't ship a `styles.css`, remove that line from both the attestation and the release step.
 
 2. In your terminal, commit the workflow.
 

--- a/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
+++ b/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
@@ -31,7 +31,7 @@ Manually releasing your plugin can be time-consuming and error-prone. In this gu
              npm run build
 
          - name: Generate artifact attestation
-           uses: actions/attest-build-provenance@v3
+           uses: actions/attest@v4
            with:
              subject-path: |
                main.js

--- a/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
+++ b/en/Plugins/Releasing/Release your plugin with GitHub Actions.md
@@ -50,7 +50,7 @@ Manually releasing your plugin can be time-consuming and error-prone. In this gu
                main.js manifest.json styles.css
    ```
 
-   The **Generate artifact attestation** step creates a signed [build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) for your release assets, which is recommended when you submit a plugin to the community directory. If your plugin doesn't ship a `styles.css`, remove that line from both the attestation and the release step.
+   The **Generate artifact attestation** step creates a signed [build provenance attestation](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) for your release assets, which is recommended when you submit a plugin to the community directory. If your plugin doesn't ship a `styles.css`, remove that line from both the attestation and the release step.
 
 2. In your terminal, commit the workflow.
 


### PR DESCRIPTION
Closes #241.

Build provenance attestations are recommended for community plugin submissions, but the example release workflow doesn't generate them.

This adds a "Generate artifact attestation" step using actions/attest-build-provenance, the id-token/attestations permissions it needs, and a short note explaining the step. Also notes how to drop styles.css if the plugin doesn't ship CSS.

Previews correctly in Reading View and follows the style guide.

---

Disclaimer / context: I manage the package security team at GitHub, which owns artifact attestations, so I'm happy to go deeper on the provenance details or adjust the approach if you'd prefer a different action or pinning strategy.