### PR TITLE
Clarify isDesktopOnly description

### DIFF
--- a/en/Reference/Manifest.md
+++ b/en/Reference/Manifest.md
@@ -25,7 +25,7 @@ The following properties are only available to plugins.
 | --------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `description`   | `string`  | **Yes**  | A description of your plugin.                                                                                                         |
 | `id`            | `string`  | **Yes**  | The ID of your plugin. The ID must contain only lowercase letters and hyphens, can't end with `plugin`, and can't contain `obsidian`. |
-| `isDesktopOnly` | `boolean` | **Yes**  | Whether your plugin uses NodeJS or Electron APIs.                                                                                     |
+| `isDesktopOnly` | `boolean` | **Yes**  | Whether the plugin can only be used on the desktop app, for example because it uses NodeJS or Electron APIs.                          |
 
 > [!note]
 > For local development, the `id` should match the plugin's folder name; otherwise some methods, such as `onExternalSettingsChange`, won't be called.


### PR DESCRIPTION
Supersedes #228, incorporating Joethei's feedback to keep the NodeJS/Electron API mention alongside the desktop-only clarification.